### PR TITLE
Revert "chore(deps): bump ua-parser-js from 0.7.21 to 0.7.28"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11749,9 +11749,9 @@
       "integrity": "sha1-QJ64VE6gM1cRIFhp7EWKsQnuEGE="
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "version": "0.7.21",
+      "resolved": "https://registry.npm.taobao.org/ua-parser-js/download/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha1-hTz5zpP2QvZxdCc8w0Vlrm8wh3c="
     },
     "uglify-js": {
       "version": "3.4.10",


### PR DESCRIPTION
Reverts bizhong/bizhong.github.io#12